### PR TITLE
Dart Editor problems on initial import

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,3 +11,4 @@ dependencies:
 #  web_ui:
 #    git: https://github.com/dart-lang/web-ui.git
   web_ui: any
+  polymer: any


### PR DESCRIPTION
Adding the `polymer`dependency to pubspec.yaml makes the editor open, parse and compile the project without errors.

Without the polymer dependency errors appear in the target[06|07]-polymer examples. pubspec.lock file references polymer, but the symlinks are not created/updated correct (screenshots attached), even when running pub install or pub update in the example folders.

_after opening the folder in Dart editor_
![polymer-error-screenshot-38](https://f.cloud.github.com/assets/70635/792533/972f96ce-eba4-11e2-9173-a36f0f12b0a9.png)

_after running pub install/update on the littleben example_
![polymer-error-screenshot-39](https://f.cloud.github.com/assets/70635/792532/970fd2e4-eba4-11e2-90d7-63ca77a8be08.png)
