### PR TITLE
fix custom element examples for Dart 1.0

### DIFF
--- a/web/count_down/count_down.html
+++ b/web/count_down/count_down.html
@@ -16,7 +16,7 @@
     
     <meta name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <script type="application/dart">import 'package:polymer/init.dart';</script>
+    <script type="application/dart">export 'package:polymer/init.dart';</script>
     <script src="packages/browser/dart.js"></script>
   </head>
   <body>

--- a/web/its_all_about_you/index.html
+++ b/web/its_all_about_you/index.html
@@ -11,7 +11,7 @@
     <title>It's All About You</title>
     <link rel="stylesheet" href="its_all_about_you.css">
     <link rel="import" href="tute_its_all_about_you.html">
-    <script type="application/dart">import 'package:polymer/init.dart';</script>
+    <script type="application/dart">export 'package:polymer/init.dart';</script>
     <script src="packages/browser/dart.js"></script>
   </head>
   <body>

--- a/web/slambook/slambook.html
+++ b/web/slambook/slambook.html
@@ -11,7 +11,7 @@
     <title>Slambook</title>
     <link rel="stylesheet" href="slambook.css">
     <link rel="import" href="tute_slambookform.html">
-    <script type="application/dart">import 'package:polymer/init.dart';</script>
+    <script type="application/dart">export 'package:polymer/init.dart';</script>
     <script src="packages/browser/dart.js"></script>
   </head>
   <body>

--- a/web/stopwatch/index.html
+++ b/web/stopwatch/index.html
@@ -10,7 +10,7 @@
     <title>Stopwatch</title>
     <link rel="stylesheet" href="stopwatch.css">
     <link rel="import" href="tute_stopwatch.html">
-    <script type="application/dart">import 'package:polymer/init.dart';</script>
+    <script type="application/dart">export 'package:polymer/init.dart';</script>
     <script src="packages/browser/dart.js"></script>
   </head>
   


### PR DESCRIPTION
When trying to run the polymer custom element examples all seem to be broken. All the documentation says you need to 'import' polymer/init.dart but it seems that needs to be export. This patch fixes that. 
