### PR TITLE
Change double quotes to single quotes

### DIFF
--- a/httpserver/bin/basic_writer_server.dart
+++ b/httpserver/bin/basic_writer_server.dart
@@ -32,12 +32,12 @@ Future main() async {
       } catch (e) {
         response
           ..statusCode = HttpStatus.internalServerError
-          ..write("Exception during file I/O: $e.");
+          ..write('Exception during file I/O: $e.');
       }
     } else {
       response
         ..statusCode = HttpStatus.methodNotAllowed
-        ..write("Unsupported request: ${req.method}.");
+        ..write('Unsupported request: ${req.method}.');
     }
     await response.close();
   }


### PR DESCRIPTION
Suggestion to change the double quotes in `basic_writer_server.dart` to single quotes to comply with the `prefer_single_quotes` rule.

I also created a PR to update the code snippet example in the documentation. https://github.com/dart-lang/site-www/pull/2229