### PR TITLE
Fix known issues: Tutorial 'Write HTTP clients & servers' doesn't workk as expected

### DIFF
--- a/httpserver/bin/mini_file_server.dart
+++ b/httpserver/bin/mini_file_server.dart
@@ -32,6 +32,7 @@ Future main() async {
       req.response.headers.contentType = ContentType.html;
       try {
         await req.response.addStream(targetFile.openRead());
+				await req.response.close();
       } catch (e) {
         print("Couldn't read file: $e");
         exit(-1);

--- a/httpserver/bin/mini_file_server.dart
+++ b/httpserver/bin/mini_file_server.dart
@@ -32,7 +32,7 @@ Future main() async {
       req.response.headers.contentType = ContentType.html;
       try {
         await req.response.addStream(targetFile.openRead());
-				await req.response.close();
+	await req.response.close();
       } catch (e) {
         print("Couldn't read file: $e");
         exit(-1);

--- a/httpserver/bin/mini_file_server.dart
+++ b/httpserver/bin/mini_file_server.dart
@@ -32,7 +32,6 @@ Future main() async {
       req.response.headers.contentType = ContentType.html;
       try {
         await req.response.addStream(targetFile.openRead());
-	await req.response.close();
       } catch (e) {
         print("Couldn't read file: $e");
         exit(-1);
@@ -40,7 +39,7 @@ Future main() async {
     } else {
       print("Can't open ${targetFile.path}.");
       req.response.statusCode = HttpStatus.notFound;
-      await req.response.close();
     }
+      await req.response.close();
   }
 }


### PR DESCRIPTION
The issue was opened [here](https://github.com/dart-lang/site-www/issues/2646). The server finally ends (closes) the response(s). The file is served as it says in the tutorial.